### PR TITLE
fujitsu: add Eco and Powerful (boost) modes as HA presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ button:
 The Fujitsu IR protocol implements Eco and Powerful as toggle commands (no state bit), so the platform tracks the assumed state internally. They are exposed in two ways:
 
 1. As HA presets (`Eco` and `Boost`) — switch them via the climate card's preset selector.
-2. As lambda methods `econo()` / `powerful()` for advanced use:
+2. As lambda methods `toggle_econo()` / `toggle_powerful()` for advanced use:
 
 ```yaml
 button:
@@ -83,11 +83,11 @@ button:
     on_press:
       then:
         - lambda: |-
-            id(my_climate).econo();
+            id(my_climate).toggle_econo();
 ```
 
 > [!NOTE]
-> Because there is no state feedback over IR, toggling Eco or Powerful from the physical IR remote will desync the assumed state until the next ESPHome-initiated change. Both default to `off` on power-on, matching a fresh boot of the indoor unit.
+> Because there is no state feedback, toggling Eco or Powerful from the physical IR remote will desync the assumed state until the next ESPHome-initiated change. Both default to `off` on power-on, matching a fresh boot of the indoor unit.
 
 ## fujitsu-264
 
@@ -167,7 +167,7 @@ climate:
 
 ## Changelog
 
-- **Unreleased**: Add Eco and Powerful presets (and `econo()` / `powerful()` lambda methods) to Fujitsu platform
+- **2026.05.16**: Add Eco and Powerful presets to Fujitsu platform
 - **2026.03.28**: Add Mitsubishi platform
 - **2026.02.21**: Add Sharp platform
 - **2026.02.19**: Use latest version of IRremoteESP8266

--- a/README.md
+++ b/README.md
@@ -69,6 +69,26 @@ button:
             id(my_climate).step_vertical();
 ```
 
+#### Eco and Powerful (boost) modes
+
+The Fujitsu IR protocol implements Eco and Powerful as toggle commands (no state bit), so the platform tracks the assumed state internally. They are exposed in two ways:
+
+1. As HA presets (`Eco` and `Boost`) — switch them via the climate card's preset selector.
+2. As lambda methods `econo()` / `powerful()` for advanced use:
+
+```yaml
+button:
+  - platform: template
+    name: 'Toggle Eco'
+    on_press:
+      then:
+        - lambda: |-
+            id(my_climate).econo();
+```
+
+> [!NOTE]
+> Because there is no state feedback over IR, toggling Eco or Powerful from the physical IR remote will desync the assumed state until the next ESPHome-initiated change. Both default to `off` on power-on, matching a fresh boot of the indoor unit.
+
 ## fujitsu-264
 
 This platform implements the special Fujitsu protocol of the `AR-RLB2J` remote.
@@ -147,6 +167,7 @@ climate:
 
 ## Changelog
 
+- **Unreleased**: Add Eco and Powerful presets (and `econo()` / `powerful()` lambda methods) to Fujitsu platform
 - **2026.03.28**: Add Mitsubishi platform
 - **2026.02.21**: Add Sharp platform
 - **2026.02.19**: Use latest version of IRremoteESP8266

--- a/components/fujitsu/fujitsu.cpp
+++ b/components/fujitsu/fujitsu.cpp
@@ -33,6 +33,15 @@ namespace esphome
                 traits.add_supported_swing_mode(climate::CLIMATE_SWING_HORIZONTAL);
                 traits.add_supported_swing_mode(climate::CLIMATE_SWING_BOTH);
             }
+            // Expose Eco and Powerful (boost) modes as HA presets. The Fujitsu IR
+            // protocol implements both as toggle commands (no state bit), so we
+            // track our assumed state internally and emit the toggle when the
+            // user changes preset. See control() and econo() / powerful() below.
+            traits.set_supported_presets({
+                climate::CLIMATE_PRESET_NONE,
+                climate::CLIMATE_PRESET_ECO,
+                climate::CLIMATE_PRESET_BOOST,
+            });
             return traits;
         }
 
@@ -40,6 +49,27 @@ namespace esphome
         {
             this->apply_state();
             this->send();
+        }
+
+        void FujitsuClimate::control(const climate::ClimateCall &call)
+        {
+            // Intercept preset changes BEFORE delegating to the parent so that
+            // we send the toggle command(s) for Eco / Powerful as needed.
+            // Parent's control() will then transmit the regular state frame
+            // for any other change (mode, temp, fan, swing).
+            if (call.get_preset().has_value())
+            {
+                auto desired_preset = *call.get_preset();
+                bool desired_econo = (desired_preset == climate::CLIMATE_PRESET_ECO);
+                bool desired_powerful = (desired_preset == climate::CLIMATE_PRESET_BOOST);
+
+                if (desired_econo != this->econo_state_)
+                    this->econo();
+                if (desired_powerful != this->powerful_state_)
+                    this->powerful();
+            }
+
+            climate_ir::ClimateIR::control(call);
         }
 
         void FujitsuClimate::step_horizontal()
@@ -61,6 +91,39 @@ namespace esphome
             this->ac_.stepVert();
             ESP_LOGI(TAG, "%s", this->ac_.toString().c_str());
             this->send();
+        }
+
+        void FujitsuClimate::econo()
+        {
+            this->ac_.setCmd(kFujitsuAcCmdEcono);
+            this->send();
+            this->econo_state_ = !this->econo_state_;
+            ESP_LOGI(TAG, "Toggling Eco (now %s)", this->econo_state_ ? "ON" : "OFF");
+            this->sync_preset_to_state();
+        }
+
+        void FujitsuClimate::powerful()
+        {
+            this->ac_.setCmd(kFujitsuAcCmdPowerful);
+            this->send();
+            this->powerful_state_ = !this->powerful_state_;
+            ESP_LOGI(TAG, "Toggling Powerful (now %s)", this->powerful_state_ ? "ON" : "OFF");
+            this->sync_preset_to_state();
+        }
+
+        // Reflect the internal Eco / Powerful tracking into HA's preset field.
+        // ECO and BOOST are mutually exclusive in HA's preset model, so when both
+        // are internally on we prefer ECO (last-toggled-wins is harder to track
+        // and not particularly useful — Eco wins as the more common everyday mode).
+        void FujitsuClimate::sync_preset_to_state()
+        {
+            if (this->econo_state_)
+                this->preset = climate::CLIMATE_PRESET_ECO;
+            else if (this->powerful_state_)
+                this->preset = climate::CLIMATE_PRESET_BOOST;
+            else
+                this->preset = climate::CLIMATE_PRESET_NONE;
+            this->publish_state();
         }
 
         void FujitsuClimate::send()

--- a/components/fujitsu/fujitsu.cpp
+++ b/components/fujitsu/fujitsu.cpp
@@ -28,20 +28,19 @@ namespace esphome
         climate::ClimateTraits FujitsuClimate::traits()
         {
             auto traits = climate_ir::ClimateIR::traits();
-            if (this->ac_.getModel() == fujitsu_ac_remote_model_t::ARRAH2E || this->ac_.getModel() == fujitsu_ac_remote_model_t::ARJW2)
+            if (this->supports_horizontal_swing())
             {
                 traits.add_supported_swing_mode(climate::CLIMATE_SWING_HORIZONTAL);
                 traits.add_supported_swing_mode(climate::CLIMATE_SWING_BOTH);
             }
-            // Expose Eco and Powerful (boost) modes as HA presets. The Fujitsu IR
-            // protocol implements both as toggle commands (no state bit), so we
-            // track our assumed state internally and emit the toggle when the
-            // user changes preset. See control() and econo() / powerful() below.
-            traits.set_supported_presets({
-                climate::CLIMATE_PRESET_NONE,
-                climate::CLIMATE_PRESET_ECO,
-                climate::CLIMATE_PRESET_BOOST,
-            });
+            if (this->supports_econo_powerful())
+            {
+                traits.set_supported_presets({
+                    climate::CLIMATE_PRESET_NONE,
+                    climate::CLIMATE_PRESET_ECO,
+                    climate::CLIMATE_PRESET_BOOST,
+                });
+            }
             return traits;
         }
 
@@ -64,9 +63,9 @@ namespace esphome
                 bool desired_powerful = (desired_preset == climate::CLIMATE_PRESET_BOOST);
 
                 if (desired_econo != this->econo_state_)
-                    this->econo();
+                    this->toggle_econo();
                 if (desired_powerful != this->powerful_state_)
-                    this->powerful();
+                    this->toggle_powerful();
             }
 
             climate_ir::ClimateIR::control(call);
@@ -74,7 +73,7 @@ namespace esphome
 
         void FujitsuClimate::step_horizontal()
         {
-            if (this->traits().supports_swing_mode(climate::CLIMATE_SWING_HORIZONTAL))
+            if (this->supports_horizontal_swing())
             {
                 this->ac_.stepHoriz();
                 ESP_LOGI(TAG, "%s", this->ac_.toString().c_str());
@@ -93,22 +92,38 @@ namespace esphome
             this->send();
         }
 
-        void FujitsuClimate::econo()
+        void FujitsuClimate::toggle_econo()
         {
-            this->ac_.setCmd(kFujitsuAcCmdEcono);
-            this->send();
-            this->econo_state_ = !this->econo_state_;
-            ESP_LOGI(TAG, "Toggling Eco (now %s)", this->econo_state_ ? "ON" : "OFF");
-            this->sync_preset_to_state();
+            if (this->supports_econo_powerful())
+            {
+                this->ac_.setCmd(kFujitsuAcCmdEcono);
+                this->send();
+                this->econo_state_ = !this->econo_state_;
+                this->powerful_state_ = false;
+                ESP_LOGI(TAG, "Toggling Eco (now %s)", this->econo_state_ ? "ON" : "OFF");
+                this->sync_preset_to_state();
+            }
+            else
+            {
+                ESP_LOGW(TAG, "Model does not support econo mode");
+            }
         }
 
-        void FujitsuClimate::powerful()
+        void FujitsuClimate::toggle_powerful()
         {
-            this->ac_.setCmd(kFujitsuAcCmdPowerful);
-            this->send();
-            this->powerful_state_ = !this->powerful_state_;
-            ESP_LOGI(TAG, "Toggling Powerful (now %s)", this->powerful_state_ ? "ON" : "OFF");
-            this->sync_preset_to_state();
+            if (this->supports_econo_powerful())
+            {
+                this->ac_.setCmd(kFujitsuAcCmdPowerful);
+                this->send();
+                this->powerful_state_ = !this->powerful_state_;
+                this->econo_state_ = false;
+                ESP_LOGI(TAG, "Toggling Powerful (now %s)", this->powerful_state_ ? "ON" : "OFF");
+                this->sync_preset_to_state();
+            }
+            else
+            {
+                ESP_LOGW(TAG, "Model does not support powerful mode");
+            }
         }
 
         // Reflect the internal Eco / Powerful tracking into HA's preset field.

--- a/components/fujitsu/fujitsu.h
+++ b/components/fujitsu/fujitsu.h
@@ -40,11 +40,11 @@ namespace esphome
             // Internally tracks the assumed Eco state, used by the ECO preset.
             // External toggles via the physical IR remote will desync this state
             // until the next ESPHome-initiated mode/temp/fan/swing change.
-            void econo();
+            void toggle_econo();
             bool is_econo() const { return this->econo_state_; }
 
             // Toggle Powerful (boost) mode. Same caveats as econo() apply.
-            void powerful();
+            void toggle_powerful();
             bool is_powerful() const { return this->powerful_state_; }
 
         protected:
@@ -55,6 +55,16 @@ namespace esphome
             void send();
             void apply_state();
             void sync_preset_to_state();
+
+            inline bool supports_horizontal_swing()
+            {
+                return this->ac_.getModel() == fujitsu_ac_remote_model_t::ARRAH2E || this->ac_.getModel() == fujitsu_ac_remote_model_t::ARJW2;
+            }
+
+            inline bool supports_econo_powerful()
+            {
+                return this->ac_.getModel() == fujitsu_ac_remote_model_t::ARREB1E || this->ac_.getModel() == fujitsu_ac_remote_model_t::ARREW4E;
+            }
 
             IRFujitsuAC ac_ = IRFujitsuAC(255); // pin is not used
 

--- a/components/fujitsu/fujitsu.h
+++ b/components/fujitsu/fujitsu.h
@@ -36,14 +36,32 @@ namespace esphome
             void step_horizontal();
             void step_vertical();
 
+            // Toggle Economy (Eco) mode. Sends a kFujitsuAcCmdEcono command frame.
+            // Internally tracks the assumed Eco state, used by the ECO preset.
+            // External toggles via the physical IR remote will desync this state
+            // until the next ESPHome-initiated mode/temp/fan/swing change.
+            void econo();
+            bool is_econo() const { return this->econo_state_; }
+
+            // Toggle Powerful (boost) mode. Same caveats as econo() apply.
+            void powerful();
+            bool is_powerful() const { return this->powerful_state_; }
+
         protected:
             void transmit_state() override;
+            void control(const climate::ClimateCall &call) override;
 
         private:
             void send();
             void apply_state();
+            void sync_preset_to_state();
 
             IRFujitsuAC ac_ = IRFujitsuAC(255); // pin is not used
+
+            // Best-effort tracking of toggle-only state bits (Eco / Powerful).
+            // Both default to false, matching a fresh power-on of the AC.
+            bool econo_state_ = false;
+            bool powerful_state_ = false;
         };
 
     } // namespace fujitsu

--- a/configurations/all.yaml
+++ b/configurations/all.yaml
@@ -53,8 +53,22 @@ climate:
 
 button:
   - platform: template
-    name: 'Step vertical'
+    name: 'Fujitsu Step vertical'
     on_press:
       then:
         - lambda: |-
             id(my_fujitsu).step_vertical();
+
+  - platform: template
+    name: 'Fujitsu Toggle econo'
+    on_press:
+      then:
+        - lambda: |-
+            id(my_fujitsu).toggle_econo();
+
+  - platform: template
+    name: 'Fujitsu Toggle powerful'
+    on_press:
+      then:
+        - lambda: |-
+            id(my_fujitsu).toggle_powerful();


### PR DESCRIPTION
This PR adds Eco and Powerful (boost) modes to the Fujitsu platform, exposing them as HA climate presets (`CLIMATE_PRESET_ECO` / `CLIMATE_PRESET_BOOST`) plus matching `econo()` / `powerful()` lambda methods (mirroring the existing `step_vertical()` / `step_horizontal()`).

## Why

The Fujitsu IR remote has dedicated Eco and Powerful buttons; the underlying `IRremoteESP8266` library exposes them via `setCmd(kFujitsuAcCmdEcono)` / `setCmd(kFujitsuAcCmdPowerful)`, but the platform did not surface them. Users wanting the same UX as their physical remote — or matching what bus-based components offer — currently have no way to access these features.

## Design

- **Toggle protocol**: both Eco and Powerful are toggle commands (kFujitsuAcCmdEcono = 0x09, kFujitsuAcCmdPowerful = 0x39), not state bits in the regular frame. Each invocation sends a short command frame and toggles the AC's internal state.
- **State tracking**: since IR is one-way, the platform tracks `econo_state_` / `powerful_state_` internally, defaulting to `false` (matching a fresh power-on).
- **HA presets**: `traits()` advertises `NONE`, `ECO`, `BOOST`. `control()` is overridden to intercept preset changes, emit the appropriate toggle(s), and then delegate to `ClimateIR::control()` for any other state changes (mode/temp/fan/swing). Switching `ECO ↔ BOOST` correctly toggles both.
- **Lambda parity**: `econo()` and `powerful()` are also exposed as public methods for users who prefer template buttons (mirroring `step_vertical()`). After each call, `sync_preset_to_state()` updates `this->preset` and calls `publish_state()` so HA stays in sync.
- **Mutual exclusivity**: when both internal flags happen to be on (e.g. user invoked the lambda methods directly), ECO wins for the displayed preset — it's the more common everyday mode.

## Caveats (documented in README)

- External toggles via the physical IR remote will desync the assumed state until the next ESPHome-initiated change. This is inherent to one-way IR and is the same constraint noted for swing position elsewhere.

## Testing

I'll be flashing this onto a Fujitsu ASHA14LGC (model ARREB1E) within the next day or two; happy to report back. Code follows the same patterns as `step_vertical()` so the risk surface should be small.