### PR TITLE
fujitsu: add optional horizontal_swing override

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,12 +57,7 @@ climate:
 
 #### Horizontal swing
 
-Whether horizontal swing is supported is normally derived from the `model`
-(it is enabled for `ARRAH2E` and `ARJW2`). Some indoor units share one of these
-remote protocols but physically lack motorized horizontal vanes — on those units
-sending a horizontal/both swing command is rejected by the unit. Use the optional
-`horizontal_swing` option to override the model-based default and hide the
-`HORIZONTAL` / `BOTH` swing modes:
+Use this option to disable horizontal swing regardless of your remote (it is enabled for `ARRAH2E` and `ARJW2`). Set it to `false` if your unit uses one of these protocols but actually lack horizontal swing.
 
 ```yaml
 climate:

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ climate:
 
 #### Horizontal swing
 
-Use this option to disable horizontal swing regardless of your remote (it is enabled for `ARRAH2E` and `ARJW2`). Set it to `false` if your unit uses one of these protocols but actually lack horizontal swing.
+Use this option to disable horizontal swing regardless of your remote (it is enabled for `ARRAH2E` and `ARJW2`). Set it to `false` if your unit uses one of these protocols but actually lacks horizontal swing.
 
 ```yaml
 climate:
@@ -179,6 +179,7 @@ climate:
 
 ## Changelog
 
+- **2026.06.06**: Add `horizontal_swing` to Fujitsu platform
 - **2026.05.16**: Add Eco and Powerful presets to Fujitsu platform
 - **2026.03.28**: Add Mitsubishi platform
 - **2026.02.21**: Add Sharp platform

--- a/README.md
+++ b/README.md
@@ -55,6 +55,26 @@ climate:
     name: 'Living Room AC'
 ```
 
+#### Horizontal swing
+
+Whether horizontal swing is supported is normally derived from the `model`
+(it is enabled for `ARRAH2E` and `ARJW2`). Some indoor units share one of these
+remote protocols but physically lack motorized horizontal vanes — on those units
+sending a horizontal/both swing command is rejected by the unit. Use the optional
+`horizontal_swing` option to override the model-based default and hide the
+`HORIZONTAL` / `BOTH` swing modes:
+
+```yaml
+climate:
+  - platform: fujitsu
+    model: ARRAH2E
+    horizontal_swing: false
+    name: 'Living Room AC'
+```
+
+When omitted, the model-based behavior is preserved (no change for existing
+configurations).
+
 #### Control fan direction
 
 You can call the `step_vertical()` and `step_horizontal()` (if supported) methods on the climate controller.

--- a/README.md
+++ b/README.md
@@ -67,9 +67,6 @@ climate:
     name: 'Living Room AC'
 ```
 
-When omitted, the model-based behavior is preserved (no change for existing
-configurations).
-
 #### Control fan direction
 
 You can call the `step_vertical()` and `step_horizontal()` (if supported) methods on the climate controller.

--- a/components/fujitsu/climate.py
+++ b/components/fujitsu/climate.py
@@ -4,6 +4,8 @@ from esphome.components import climate_ir
 from esphome.components import ir_remote_base
 from esphome.const import CONF_MODEL
 
+CONF_HORIZONTAL_SWING = "horizontal_swing"
+
 AUTO_LOAD = ["climate_ir", "ir_remote_base"]
 
 fujitsu_ns = cg.esphome_ns.namespace("fujitsu")
@@ -22,6 +24,7 @@ MODELS = {
 CONFIG_SCHEMA = climate_ir.climate_ir_with_receiver_schema(FujitsuClimate).extend(
     {
         cv.Required(CONF_MODEL): cv.enum(MODELS),
+        cv.Optional(CONF_HORIZONTAL_SWING): cv.boolean,
     }
 )
 
@@ -31,3 +34,5 @@ async def to_code(config):
 
     var = await climate_ir.new_climate_ir(config)
     cg.add(var.set_model(config[CONF_MODEL]))
+    if CONF_HORIZONTAL_SWING in config:
+        cg.add(var.set_horizontal_swing_supported(config[CONF_HORIZONTAL_SWING]))

--- a/components/fujitsu/fujitsu.h
+++ b/components/fujitsu/fujitsu.h
@@ -64,7 +64,9 @@ namespace esphome
             inline bool supports_horizontal_swing()
             {
                 if (this->horizontal_swing_override_.has_value())
+                {
                     return this->horizontal_swing_override_.value();
+                }
                 return this->ac_.getModel() == fujitsu_ac_remote_model_t::ARRAH2E || this->ac_.getModel() == fujitsu_ac_remote_model_t::ARJW2;
             }
 

--- a/components/fujitsu/fujitsu.h
+++ b/components/fujitsu/fujitsu.h
@@ -31,12 +31,8 @@ namespace esphome
 
             void set_model(const Model model);
 
-            // Override the model-based detection of horizontal swing support.
-            // Some units share a remote protocol that defaults to horizontal
-            // swing (e.g. ARRAH2E) but physically lack motorized horizontal
-            // vanes; sending a horizontal/both swing command makes those units
-            // reject the frame. Set to false via the `horizontal_swing` YAML
-            // option to hide HORIZONTAL/BOTH from the exposed swing modes.
+            // Override the model-based detection of horizontal swing support
+            // (enabled by default for `ARRAH2E` and `ARJW2` models)
             void set_horizontal_swing_supported(bool supported) { this->horizontal_swing_override_ = supported; }
 
             void setup() override;

--- a/components/fujitsu/fujitsu.h
+++ b/components/fujitsu/fujitsu.h
@@ -3,6 +3,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/component.h"
 #include "esphome/core/automation.h"
+#include "esphome/core/optional.h"
 #include "esphome/components/ir_remote_base/ir_remote_base.h"
 #include "ir_Fujitsu.h"
 
@@ -29,6 +30,14 @@ namespace esphome
                                {climate::CLIMATE_SWING_OFF, climate::CLIMATE_SWING_VERTICAL}) {}
 
             void set_model(const Model model);
+
+            // Override the model-based detection of horizontal swing support.
+            // Some units share a remote protocol that defaults to horizontal
+            // swing (e.g. ARRAH2E) but physically lack motorized horizontal
+            // vanes; sending a horizontal/both swing command makes those units
+            // reject the frame. Set to false via the `horizontal_swing` YAML
+            // option to hide HORIZONTAL/BOTH from the exposed swing modes.
+            void set_horizontal_swing_supported(bool supported) { this->horizontal_swing_override_ = supported; }
 
             void setup() override;
             climate::ClimateTraits traits() override;
@@ -58,6 +67,8 @@ namespace esphome
 
             inline bool supports_horizontal_swing()
             {
+                if (this->horizontal_swing_override_.has_value())
+                    return this->horizontal_swing_override_.value();
                 return this->ac_.getModel() == fujitsu_ac_remote_model_t::ARRAH2E || this->ac_.getModel() == fujitsu_ac_remote_model_t::ARJW2;
             }
 
@@ -72,6 +83,10 @@ namespace esphome
             // Both default to false, matching a fresh power-on of the AC.
             bool econo_state_ = false;
             bool powerful_state_ = false;
+
+            // When set, overrides the model-based horizontal swing detection.
+            // Unset (default) preserves the previous model-driven behavior.
+            optional<bool> horizontal_swing_override_;
         };
 
     } // namespace fujitsu

--- a/components/fujitsu/fujitsu.h
+++ b/components/fujitsu/fujitsu.h
@@ -33,7 +33,10 @@ namespace esphome
 
             // Override the model-based detection of horizontal swing support
             // (enabled by default for `ARRAH2E` and `ARJW2` models)
-            void set_horizontal_swing_supported(bool supported) { this->horizontal_swing_override_ = supported; }
+            void set_horizontal_swing_supported(bool supported)
+            {
+                this->horizontal_swing_override_ = supported;
+            }
 
             void setup() override;
             climate::ClimateTraits traits() override;
@@ -82,8 +85,6 @@ namespace esphome
             bool econo_state_ = false;
             bool powerful_state_ = false;
 
-            // When set, overrides the model-based horizontal swing detection.
-            // Unset (default) preserves the previous model-driven behavior.
             optional<bool> horizontal_swing_override_;
         };
 

--- a/configurations/all.yaml
+++ b/configurations/all.yaml
@@ -24,6 +24,7 @@ climate:
   - platform: fujitsu
     id: my_fujitsu
     model: ARREB1E
+    horizontal_swing: false
     name: 'Fujitsu'
 
   - platform: panasonic


### PR DESCRIPTION
## Summary

Horizontal swing support in the `fujitsu` platform is inferred solely from the `model` option (enabled for `ARRAH2E` and `ARJW2`). However, horizontal-vane presence is a property of the indoor **unit**, while `model` selects the **remote protocol** — and a single protocol covers many units with different vane hardware. So some units that correctly use a horizontal-swing-capable protocol physically lack motorized horizontal vanes, and a `HORIZONTAL`/`BOTH` swing command is rejected by the unit (it beeps/blinks an error and ignores the command).

### Concrete example

The **AR-RAE1E** remote maps to **`ARRAH2E`** per [SupportedProtocols.md](https://github.com/crankyoldgit/IRremoteESP8266/blob/master/SupportedProtocols.md) (A/C Model column). `ARRAH2E` unconditionally exposes `HORIZONTAL`/`BOTH`, but the corresponding indoor unit has only a vertical vane. `ARRAH2E` is the correct protocol for this remote (switching to `ARREB1E` would be the wrong protocol and also mis-encodes the Eco/Powerful toggles), so the only way to hide the unsupported swing modes is from configuration.

There is currently no way to limit the exposed swing modes from YAML (unlike the `midea` platform, which exposes `supported_swing_modes`).

> Note: the related upstream report [crankyoldgit/IRremoteESP8266#1376](https://github.com/crankyoldgit/IRremoteESP8266/issues/1376) is an AR-RAH1U, which maps to `ARREB1E` and is solved by selecting the correct model — it is **not** a motivation for this PR. The motivation is the `ARRAH2E`-mapped units above, where no model selection removes the unsupported swing modes.

## Change

Adds an optional `horizontal_swing` boolean to the `fujitsu` platform that overrides the model-based detection:

```yaml
climate:
  - platform: fujitsu
    model: ARRAH2E
    horizontal_swing: false   # hide HORIZONTAL / BOTH swing modes
    name: 'Living Room AC'
```

- When **omitted** (default), behavior is unchanged — support is still derived from the model, so existing configurations are unaffected.
- When **set**, it forces `supports_horizontal_swing()` to the given value, which in turn controls whether `HORIZONTAL`/`BOTH` are added in `traits()` (and gates `step_horizontal()`).

Implemented with an `optional<bool>` so "unset" is distinguishable from "explicitly false".

## Files
- `components/fujitsu/climate.py` — new optional config key, wired to a setter.
- `components/fujitsu/fujitsu.h` — `set_horizontal_swing_supported()` setter, `optional<bool>` member, override branch in `supports_horizontal_swing()`.
- `README.md` — documents the new option under the fujitsu section.

## Testing
Compiled and flashed (OTA) on an ESP32 driving a Fujitsu unit via IR with `model: ARRAH2E` and `horizontal_swing: false`: the climate entity now exposes only `off`/`vertical` swing modes, and the unit no longer rejects swing commands. With the option omitted, the swing modes are unchanged. The repo's CI build validation passes on this branch.